### PR TITLE
Remove `maxFragmentCombinedOutputResources` from correspondence

### DIFF
--- a/correspondence/index.bs
+++ b/correspondence/index.bs
@@ -184,11 +184,6 @@ User agents are not required to use these formulas and may expose whatever they 
         <td>`maxVertexInputBindings`
         <td>[16](https://docs.microsoft.com/en-ca/windows/win32/api/d3d12/ns-d3d12-d3d12_input_element_desc)
     <tr>
-        <th>`maxFragmentCombinedOutputResources`
-        <td>[#3829](https://github.com/gpuweb/gpuweb/pull/3829), [#1343](https://github.com/gpuweb/gpuweb/issues/1343)
-        <td>`maxFragmentCombinedOutputResources`
-        <td colspan=2>*No separate limit.* Use `maxColorAttachments + maxStorageBuffersPerShaderStage + maxStorageTexturesPerShaderStage`.
-    <tr>
         <th>`maxUniformBufferBindingSize`
         <td>[#803](https://github.com/gpuweb/gpuweb/issues/803)
         <td>`maxUniformBufferRange`


### PR DESCRIPTION
Has been removed in https://github.com/gpuweb/gpuweb/pull/4044